### PR TITLE
Fix config for WRN-28-10-dropout_cifar10

### DIFF
--- a/models_dir/wrn-28-10-dropout_cifar10/config.yaml
+++ b/models_dir/wrn-28-10-dropout_cifar10/config.yaml
@@ -1,5 +1,5 @@
 backend: nccl
-world_size: 2
+world_size: 1
 master_addr: localhost
 master_port: '12345'
 dataset_cls_name: CIFAR10


### PR DESCRIPTION
We ended up using one Tesla V100 GPU on Google Cloud Platform, and forgot to change this config locally, so here's the fix.  